### PR TITLE
Cant click on empty edit box

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -145,8 +145,10 @@ local function RefreshEditBoxFromList(editBoxName, listName)
 	editBoxName:ClearFocus()
 	editBoxName:SetText(table.concat(listName, "\n"))
 	
-	local _, lineHeight = editBoxName:GetFontObject():GetFont()
- 	editBoxName:SetHeight(lineHeight * #listName)
+	if #listName > 0 then
+		local _, lineHeight = editBoxName:GetFontObject():GetFont()
+		editBoxName:SetHeight(lineHeight * #listName)
+	end
 	editBoxName.scrollFrame:SetVerticalScroll(0)
 end
 


### PR DESCRIPTION
BUG:
1. Click on the whitelist or blacklist
2. Delete everything in it
3. Click 'accept'
4. The whitelist/blacklist can no longer be typed into until the next UI refresh.

This patch fixes that issue.
