### PR TITLE
Whitelist checkbox

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -94,6 +94,8 @@ ChatCleanerBlacklist = {
 	"youtu%.?be",
 }
 
+WhitelistAllNumberedChannels = true
+
 local TRADE = L.Trade
 local reqLatin = not strmatch(GetLocale(), "^[rkz][uoh]")
 
@@ -126,9 +128,9 @@ ChatFrame_AddMessageEventFilter("CHAT_MSG_CHANNEL", function(_, _, message, send
 			return true
 		end
 	end
-
-	-- Apply only the blacklist to non-Trade channels
-	if not strfind(channelName, TRADE) then
+	
+	-- Don't apply the whitelist to non-Trade channels if WhitelistAllNumberedChannels is false
+	if not WhitelistAllNumberedChannels and not strfind(channelName, TRADE) then
 		return
 	end
 	

--- a/Options.lua
+++ b/Options.lua
@@ -184,7 +184,15 @@ Whitelist:SetPoint("BOTTOMRIGHT", -16, 16)
 Whitelist.label:SetText(L.Whitelist)
 Options.Whitelist = Whitelist
 
-Blacklist.acceptButton:SetScript("OnClick", function(self)
+local CheckboxWhitelistChannels = CreateFrame("CheckButton", "$parentCheckboxWhitelistChannels", Options, "ChatConfigCheckButtonTemplate")
+CheckboxWhitelistChannels:SetScript("OnClick", function(this)
+	WhitelistAllNumberedChannels = CheckboxWhitelistChannels:GetChecked()
+end)
+_G[CheckboxWhitelistChannels:GetName().."Text"]:SetText(L.CheckboxWhitelistChannelsLabel)
+CheckboxWhitelistChannels.tooltip = L.CheckboxWhitelistChannelsTooltip
+CheckboxWhitelistChannels:SetPoint("TOPLEFT", 316, -62)
+
+Blacklist.acceptButton:SetScript("OnClick", function(this)
 	FillListFromText(ChatCleanerBlacklist, Blacklist:GetText())
 	Options:refresh()
 end)
@@ -200,6 +208,8 @@ function Options:refresh()
 
 	table.sort(ChatCleanerWhitelist)
 	FillEditBoxFromList(Whitelist, ChatCleanerWhitelist)
+	
+	CheckboxWhitelistChannels:SetChecked(WhitelistAllNumberedChannels)
 end
 
 Options:refresh()

--- a/Strings.lua
+++ b/Strings.lua
@@ -13,6 +13,8 @@ L.Trade = "Trade"
 L.Blacklist = "Blacklisted Words"
 L.Whitelist = "Whitelisted Words"
 L.Description = "Messages in Trade chat are blocked unless they contain at least one whitelisted word |cffffd200and|r do not contain any blacklisted words. The blacklist (but not the whitelist) is also applied to General chat."
+L.CheckboxWhitelistChannelsLabel = " Whitelist all numbered channels"
+L.CheckboxWhitelistChannelsTooltip = "When enabled, the whitelist applies to all numbered chat channels. When disabled, it only applies to Trade chat."
 
 local LOC = GetLocale()
 if LOC == "deDE" then

--- a/TradeChatCleaner.toc
+++ b/TradeChatCleaner.toc
@@ -12,7 +12,7 @@
 ## X-Copyright: Copyright (c) 2013-2014 Phanx. All rights reserved.
 ## X-Website: https://github.com/Phanx/TradeChatCleaner
 
-## SavedVariables: ChatCleanerBlacklist, ChatCleanerWhitelist
+## SavedVariables: ChatCleanerBlacklist, ChatCleanerWhitelist, WhitelistAllNumberedChannels
 
 Strings.lua
 


### PR DESCRIPTION
Added a checkbox to the options menu to toggle whether the whitelist is applied to all numbered channels, or only the trade channel.
